### PR TITLE
Allow Interflux Admins to approve companies as ICSF suppliers

### DIFF
--- a/app/models/company.js
+++ b/app/models/company.js
@@ -20,12 +20,12 @@ export default class CompanyModel extends Model {
   @attr('boolean') isHeadquarter;
   @attr('boolean') shownOnMainWebsite;
   @attr('boolean') shownOnGroupWebsite;
+  @attr('boolean') shownOnIcsfWebsite;
   @attr('string') coreActivity;
   @attr('string') history;
   @attr('number') rankOnGroupWebsite;
   @attr('number') headCount;
   @attr('boolean') showMarkets;
-  @attr('boolean') approvedIcsfSupplier;
 
   @belongsTo('country') country;
 

--- a/app/models/company.js
+++ b/app/models/company.js
@@ -25,6 +25,7 @@ export default class CompanyModel extends Model {
   @attr('number') rankOnGroupWebsite;
   @attr('number') headCount;
   @attr('boolean') showMarkets;
+  @attr('boolean') approvedIcsfSupplier;
 
   @belongsTo('country') country;
 

--- a/app/pods/secure/companies/company/controller.js
+++ b/app/pods/secure/companies/company/controller.js
@@ -36,7 +36,8 @@ export default class CompanyController extends Controller {
     }
     this.company.setProperties({
       shownOnMainWebsite: false,
-      shownOnGroupWebsite: false
+      shownOnGroupWebsite: false,
+      approvedIcsfSupplier: false
     });
     this.company.save();
   }

--- a/app/pods/secure/companies/company/controller.js
+++ b/app/pods/secure/companies/company/controller.js
@@ -37,7 +37,7 @@ export default class CompanyController extends Controller {
     this.company.setProperties({
       shownOnMainWebsite: false,
       shownOnGroupWebsite: false,
-      approvedIcsfSupplier: false
+      shownOnIcsfWebsite: false
     });
     this.company.save();
   }

--- a/app/pods/secure/companies/company/template.hbs
+++ b/app/pods/secure/companies/company/template.hbs
@@ -134,6 +134,15 @@
         @attribute='shownOnGroupWebsite'
         @layout='horizontal'
       />
+
+      <Field::Boolean::Pills
+        @label='Shown on jetfluxer.com?'
+        @legend='Select "yes" if this company is an approved ICSF supplier.'
+        @record={{company}}
+        @attribute='approvedIcsfSupplier'
+        @layout='horizontal'
+      />
+
     {{/if}}
 
     {{#if company.public}}

--- a/app/pods/secure/companies/company/template.hbs
+++ b/app/pods/secure/companies/company/template.hbs
@@ -139,7 +139,7 @@
         @label='Shown on jetfluxer.com?'
         @legend='Select "yes" if this company is an approved ICSF supplier.'
         @record={{company}}
-        @attribute='approvedIcsfSupplier'
+        @attribute='shownOnIcsfWebsite'
         @layout='horizontal'
       />
 


### PR DESCRIPTION
This PR:

* Allow Interflux Admins to approve companies as ICSF suppliers

![CleanShot 2024-01-27 at 21 21 45](https://github.com/interflux-electronics/interflux-admin-ember-frontend/assets/4415419/d3525211-fa36-4bb4-9eec-d0a37ce5f968)
